### PR TITLE
Use run_started_at instead of created_at

### DIFF
--- a/action/lib/index.js
+++ b/action/lib/index.js
@@ -20,13 +20,13 @@ export default async function ({ token, delay, timeout }) {
   const { runId: run_id } = github.context
 
   // get workflow id and created date from run id
-  const { data: { workflow_id, created_at } } = await octokit.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
+  const { data: { workflow_id, run_started_at } } = await octokit.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', {
     ...github.context.repo,
     run_id
   })
 
   // date to check against
-  const before = new Date(created_at)
+  const before = new Date(run_started_at)
 
   core.info(`searching for workflow runs before ${before}`)
 

--- a/action/lib/runs.js
+++ b/action/lib/runs.js
@@ -21,7 +21,7 @@ export default async function ({ octokit, workflow_id, run_id, before }) {
     // exclude this one
     .filter(run => run.id !== run_id)
     // get older runs
-    .filter(run => new Date(run.created_at) < before)
+    .filter(run => new Date(run.run_started_at) < before)
 
   core.info(`found ${waiting_for.length} workflow runs`)
   core.debug(inspect(waiting_for.map(run => ({ id: run.id, name: run.name }))))


### PR DESCRIPTION
This will fix a problem where a 're-run' will start even if there is a newer run started