### PR TITLE
Add more statuses to runs.js

### DIFF
--- a/src/lib/runs.js
+++ b/src/lib/runs.js
@@ -17,7 +17,7 @@ export default async function ({ octokit, workflow_id, run_id, before }) {
   // find any instances of the same workflow
   const waiting_for = workflow_runs
     // limit to currently running ones
-    .filter(run => ['in_progress', 'queued'].includes(run.status))
+    .filter(run => ['in_progress', 'queued', 'waiting', 'pending', 'action_required', 'requested'].includes(run.status))
     // exclude this one
     .filter(run => run.id !== run_id)
     // get older runs


### PR DESCRIPTION
I found out that this doesn't check for certain statuses like 'waiting' on currently running jobs, which breaks the concurrency lock. This update adds them in.  I've tested this out in a private repo.